### PR TITLE
fix: export GuardianApprovedItem as a type

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aelf-web-login/wallet-adapter-base",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.2",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aelf-web-login/wallet-adapter-bridge",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.2",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -61,6 +61,6 @@ export function initBridge({ baseConfig, wallets, didConfig }: IConfigProps): IB
 }
 
 export * as PortkeyDid from '@portkey/did-ui-react';
-export { GuardianApprovedItem } from '@portkey/did-ui-react';
+export type { GuardianApprovedItem } from '@portkey/did-ui-react';
 
 // export { demoFn } from './ui';

--- a/packages/bridge/src/ui.tsx
+++ b/packages/bridge/src/ui.tsx
@@ -568,7 +568,7 @@ const SignInModal: React.FC<ISignInModalProps> = (props: ISignInModalProps) => {
         </DynamicWrapper>
       )}
 
-      {guardianList?.length && (
+      {guardianList?.length > 0 && (
         <GuardianApprovalModal
           open={showGuardianApprovalModal}
           networkType={baseConfig.networkType}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aelf-web-login/wallet-adapter-react",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.2",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aelf-web-login/utils",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.2",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/wallets/night-elf/package.json
+++ b/packages/wallets/night-elf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aelf-web-login/wallet-adapter-night-elf",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.2",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/wallets/portkey-aa/package.json
+++ b/packages/wallets/portkey-aa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aelf-web-login/wallet-adapter-portkey-aa",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.2",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",

--- a/packages/wallets/portkey-discover/package.json
+++ b/packages/wallets/portkey-discover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aelf-web-login/wallet-adapter-portkey-discover",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.2",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
export GuardianApprovedItem as a type